### PR TITLE
fix: repair album merge/delete/share for API-key auth mode

### DIFF
--- a/src/pages/api/albums/delete.ts
+++ b/src/pages/api/albums/delete.ts
@@ -1,5 +1,7 @@
 import { ENV } from "@/config/environment";
 import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { getUserHeaders } from "@/helpers/user.helper";
+import { IUser } from "@/types/user";
 import { NextApiResponse } from "next";
 
 import { NextApiRequest } from "next";
@@ -11,13 +13,11 @@ interface IAlbumShare {
   showMetadata: boolean;
 }
 
-const deleteSingleAlbum = async (albumId: string, token: string) => {
+const deleteSingleAlbum = async (albumId: string, currentUser: IUser) => {
   const url = ENV.IMMICH_URL + "/api/albums/" + albumId;
   return fetch(url, {
     method: 'DELETE',
-    headers: {
-      'Authorization': `Bearer ${token}`
-    }
+    headers: getUserHeaders(currentUser)
   }).then(async (response) => {
     if (response.status >= 400) {
       return {
@@ -44,7 +44,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const deleteResults = await Promise.all(albumIds.map(async (albumId) => {
-    return deleteSingleAlbum(albumId, currentUser.accessToken);
+    return deleteSingleAlbum(albumId, currentUser);
   }));
   return res.status(200).json(deleteResults);
 }

--- a/src/pages/api/albums/merge.ts
+++ b/src/pages/api/albums/merge.ts
@@ -2,6 +2,7 @@ import { db } from "@/config/db";
 import { ENV } from "@/config/environment";
 import { ADD_ASSETS_TO_ALBUM_PATH, DELETE_ALBUMS_PATH } from "@/config/routes";
 import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { getUserHeaders } from "@/helpers/user.helper";
 import API from "@/lib/api";
 import { albumsAssetsAssets } from "@/schema/albumAssetsAssets.schema";
 import { albums } from "@/schema/albums.schema";
@@ -49,7 +50,7 @@ export default async function handler(
     )
     .limit(1);
 
-  if (!primaryAlbum) {
+  if (primaryAlbum.length === 0) {
     return res.status(404).json({ error: "Primary album not found" });
   }
 
@@ -73,20 +74,27 @@ export default async function handler(
     return res.status(404).json({ error: "Secondary album assets not found" });
   }
 
-  const secondaryAlbumAssetsIds = secondaryAlbumAssets.map((albumAsset) => albumAsset.assetId);
+  const secondaryAlbumAssetsIds = Array.from(
+    new Set(secondaryAlbumAssets.map((albumAsset) => albumAsset.assetId))
+  );
 
   const addAssetsToPrimaryAlbumURL = `${ENV.IMMICH_URL}/api/albums/${primaryAlbumId}/assets`;
   const addAssetsToPrimaryAlbum = await fetch(addAssetsToPrimaryAlbumURL, {
     method: 'PUT',
     body: JSON.stringify({ ids: secondaryAlbumAssetsIds }),
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${currentUser.accessToken}`
-    }
+    headers: getUserHeaders(currentUser, { "Content-Type": "application/json" })
   });
-  
+
   if (!addAssetsToPrimaryAlbum.ok) {
-    return res.status(500).json({ error: "Failed to add assets to primary album" });
+    const errorBody = await addAssetsToPrimaryAlbum.text();
+    console.error(
+      `[albums/merge] Immich rejected add-assets request (status ${addAssetsToPrimaryAlbum.status}): ${errorBody}`
+    );
+    return res.status(500).json({
+      error: "Failed to add assets to primary album",
+      immichStatus: addAssetsToPrimaryAlbum.status,
+      immichError: errorBody,
+    });
   }
 
   // Delete secondary albums
@@ -94,9 +102,7 @@ export default async function handler(
     const deleteAlbumURL = `${ENV.IMMICH_URL}/api/albums/${album.id}`;
     return fetch(deleteAlbumURL, {
       method: 'DELETE',
-      headers: {
-        'Authorization': `Bearer ${currentUser.accessToken}`
-      }
+      headers: getUserHeaders(currentUser)
     });
   });  
 

--- a/src/pages/api/albums/share.ts
+++ b/src/pages/api/albums/share.ts
@@ -1,5 +1,7 @@
 import { ENV } from "@/config/environment";
 import { getCurrentUser } from "@/handlers/serverUtils/user.utils";
+import { getUserHeaders } from "@/helpers/user.helper";
+import { IUser } from "@/types/user";
 import { NextApiResponse } from "next";
 
 import { NextApiRequest } from "next";
@@ -11,21 +13,18 @@ interface IAlbumShare {
   showMetadata: boolean;
 }
 
-const generateShareLink = async (album: IAlbumShare, token: string) => {
+const generateShareLink = async (album: IAlbumShare, currentUser: IUser) => {
   const url = ENV.IMMICH_URL + "/api/shared-links";
   return fetch(url, {
     method: 'POST',
-    body: JSON.stringify({ 
+    body: JSON.stringify({
       type: "ALBUM",
-      albumId: album.albumId, 
+      albumId: album.albumId,
       allowDownload: album.allowDownload,
       allowUpload: album.allowUpload,
       showMetadata: album.showMetadata,
     }),
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
-    }
+    headers: getUserHeaders(currentUser, { "Content-Type": "application/json" })
   }).then(async (response) => {
     if (response.status >= 400) {
       return {
@@ -55,7 +54,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const shareLinks = await Promise.all(albums.map(async (album) => {
-    return generateShareLink(album, currentUser.accessToken);
+    return generateShareLink(album, currentUser);
   }));
   return res.status(200).json(shareLinks);
 }


### PR DESCRIPTION
## Summary

- Merge, delete, and share album endpoints built Immich API requests with `Authorization: Bearer ${currentUser.accessToken}`, but `accessToken` is only populated for session-cookie logins. When authenticating via the global `IMMICH_API_KEY` (no per-user session, `isUsingAPIKey: true`), `accessToken` is `undefined`, so Immich received `Bearer undefined` and rejected the request with `401 Invalid user token` — surfaced to users as a generic 500 when merging albums.
- Switched all three routes to the existing `getUserHeaders()` helper (`src/helpers/user.helper.ts`), which already picks the right header (`x-api-key` vs `Authorization: Bearer`) based on auth mode and is used consistently everywhere else in the codebase. `merge.ts`/`delete.ts`/`share.ts` were the outliers that built headers by hand.
- `merge.ts` specifically also had two more bugs fixed:
  - Deduplicated asset IDs collected across the albums being merged — Immich's bulk add-assets call was rejecting the whole request when the same asset appeared more than once, which happens whenever the merged albums have overlapping photos.
  - Fixed a dead `if (!primaryAlbum)` 404 check that could never trigger, since a Drizzle `select()` result is always a truthy array even when empty.

## Test plan

- [x] Reproduced the original bug against a real Immich instance running in API-key auth mode: confirmed the 401 `Invalid user token` from Immich via added (and since removed) debug logging.
- [x] Applied the fix and re-ran the merge against two real overlapping albums (72 and 64 photos, ~54 duplicates) — got `200 success`, the two albums correctly combined into one with duplicates deduped, and the secondary album was deleted.
- [ ] No automated test suite in the repo for these API routes; verified manually end-to-end as above.

Fixes: https://github.com/immich-power-tools/immich-power-tools/issues/202