### PR TITLE
fix(ai): send full ISO datetimes to Immich search API

### DIFF
--- a/src/helpers/ai.helper.ts
+++ b/src/helpers/ai.helper.ts
@@ -19,6 +19,12 @@ interface FindQuery {
 
 const allowedTypes = ["IMAGE", "VIDEO", "AUDIO"];
 
+// Immich's search API validates takenAfter/takenBefore as full ISO 8601
+// datetimes and rejects a bare YYYY-MM-DD value with
+// `invalid_format` / `format: "datetime"`, so date-only values must be expanded
+// before they reach the API.
+const isDateOnly = (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value);
+
 
 const responseSchema = z.object({
   query: z.string().describe("Gist of the query. Remove the details of tags"),
@@ -105,6 +111,18 @@ export const parseFindQuery = async (query: string): Promise<FindQuery> => {
   }
   if (parsedResponse.takenBefore && parsedResponse.takenBefore > today) {
     delete parsedResponse.takenBefore;
+  }
+
+  // Expand date-only values into the datetimes Immich expects. This must run
+  // after the guardrail above, which compares plain YYYY-MM-DD strings.
+  // takenBefore uses the end of the day so that a single-day range (e.g.
+  // "videos yesterday", where both bounds are the same date) still covers the
+  // whole day instead of being an empty interval.
+  if (parsedResponse.takenAfter && isDateOnly(parsedResponse.takenAfter)) {
+    parsedResponse.takenAfter = `${parsedResponse.takenAfter}T00:00:00.000Z`;
+  }
+  if (parsedResponse.takenBefore && isDateOnly(parsedResponse.takenBefore)) {
+    parsedResponse.takenBefore = `${parsedResponse.takenBefore}T23:59:59.999Z`;
   }
 
   return removeNullOrUndefinedProperties(parsedResponse) as any as FindQuery;


### PR DESCRIPTION
## Problem

Smart Search builds its date filters as plain `YYYY-MM-DD` strings, but the Immich search API validates `takenAfter` / `takenBefore` as full ISO 8601 datetimes. Any natural-language search that mentions a date is therefore rejected by the API and surfaces in the UI as **"Failed to fetch assets"**.

## Reproduction

Against an Immich v3.0.3 instance, `POST /api/search/smart`:

```bash
# 1. no date -> works
curl -X POST "$IMMICH_URL/api/search/smart" \
  -H 'x-api-key: ***' -H 'Content-Type: application/json' \
  -d '{"query":"dog"}'
# HTTP 200

# 2. date-only -> rejected
curl -X POST "$IMMICH_URL/api/search/smart" \
  -H 'x-api-key: ***' -H 'Content-Type: application/json' \
  -d '{"query":"dog","takenAfter":"2025-06-01"}'
# HTTP 400
# {"message":"Validation failed","errors":[{"origin":"string","code":"invalid_format","format":"datetime",...}]}

# 3. full datetime -> works
curl -X POST "$IMMICH_URL/api/search/smart" \
  -H 'x-api-key: ***' -H 'Content-Type: application/json' \
  -d '{"query":"dog","takenAfter":"2025-06-01T00:00:00.000Z"}'
# HTTP 200
```

## Impact

Out of 8 natural-language Smart Search queries tested, the 4 that contained a date (e.g. "photos from last summer", "videos yesterday") failed with HTTP 400. Every date-based Smart Search is currently broken.

## Fix

`parseFindQuery` now expands date-only values into the datetimes the API expects, and leaves values that are already full datetimes untouched:

- `takenAfter` -> `${date}T00:00:00.000Z` (start of day)
- `takenBefore` -> `${date}T23:59:59.999Z` (end of day)

### Why `23:59:59.999Z` for `takenBefore`

A query like *"videos yesterday"* produces the **same date** for both bounds. If both were normalized to `00:00:00.000Z`, the range would be empty and could never match an asset. Using the end of the day keeps a single-day range covering the whole day.

### Why the normalization runs after the existing guardrail

The existing guardrail compares `takenAfter` / `takenBefore` against `today` as plain `YYYY-MM-DD` strings. Normalizing before it would break that string comparison (`"2026-08-23T00:00:00.000Z" >= "2026-08-23"`), so the new code is placed strictly after it and the guardrail itself is left unchanged.

## Notes

- Single file touched (`src/helpers/ai.helper.ts`), +18/-0, no refactor and no new dependency.
- Values that already contain a time component pass through unchanged, so this is backwards compatible with any model output that already returns a datetime.
